### PR TITLE
Make server tell client about installed microblocks

### DIFF
--- a/codechicken/microblock/MicroMaterialRegistry.scala
+++ b/codechicken/microblock/MicroMaterialRegistry.scala
@@ -16,6 +16,7 @@ import net.minecraft.util.Icon
 import net.minecraft.entity.player.EntityPlayer
 import codechicken.lib.render.Vertex5
 import net.minecraft.item.ItemStack
+import scala.collection.mutable.ListBuffer
 
 object MicroMaterialRegistry
 {
@@ -82,20 +83,22 @@ object MicroMaterialRegistry
         idMap.foreach(e => packet.writeString(e._1))
     }
     
-    def readIDMap(packet:PacketCustom)
+    def readIDMap(packet:PacketCustom):Seq[String] =
     {
         val k = packet.readInt()
         idWriter.setMax(k)
         idMap = new Array(k)
+        val missing = ListBuffer[String]()
         for(i <- 0 until k)
         {
             val s = packet.readString()
             val v = typeMap.get(s)
             if(v.isEmpty)
-                throw new IllegalArgumentException("The microblock with ID "+s+" is not installed on the client");//TODO: fancy FML thingy
-            
-            idMap(i) = (s, v.get)
+                missing+=s
+            else
+                idMap(i) = (s, v.get)
         }
+        return missing
     }
     
     def writePartID(data:MCDataOutput, id:Int)

--- a/codechicken/microblock/handler/EventHandler.scala
+++ b/codechicken/microblock/handler/EventHandler.scala
@@ -13,8 +13,16 @@ import org.lwjgl.opengl.GL11
 import codechicken.lib.render.RenderUtils
 import cpw.mods.fml.relauncher.SideOnly
 import cpw.mods.fml.relauncher.Side
+import cpw.mods.fml.common.network.IConnectionHandler
+import cpw.mods.fml.common.network.Player
+import net.minecraft.network.INetworkManager
+import net.minecraft.network.NetLoginHandler
+import codechicken.lib.packet.PacketCustom
+import net.minecraft.network.packet.NetHandler
+import net.minecraft.network.packet.Packet1Login
+import net.minecraft.server.MinecraftServer
 
-object MicroblockEventHandler
+object MicroblockEventHandler extends IConnectionHandler
 {
     @ForgeSubscribe
     @SideOnly(Side.CLIENT)
@@ -38,4 +46,18 @@ object MicroblockEventHandler
             GL11.glPopMatrix()
         }
     }
+    
+    def connectionReceived(loginHandler:NetLoginHandler, netManager:INetworkManager):String = 
+    {
+        val packet = new PacketCustom(MicroblockSPH.registryChannel, 1)
+        MicroMaterialRegistry.writeIDMap(packet)
+        netManager.addToSendQueue(packet.toPacket)
+        return null
+    }
+    
+    def clientLoggedIn(netHandler:NetHandler, netManager:INetworkManager, packet:Packet1Login){}
+    def playerLoggedIn(player:Player, netHandler:NetHandler, netManager:INetworkManager){}
+    def connectionOpened(netHandler:NetHandler, server:String, port:Int, netManager:INetworkManager){}
+    def connectionOpened(netHandler:NetHandler, server:MinecraftServer, netManager:INetworkManager){}
+    def connectionClosed(netManager:INetworkManager){}
 }

--- a/codechicken/microblock/handler/ModContainer.scala
+++ b/codechicken/microblock/handler/ModContainer.scala
@@ -14,9 +14,11 @@ import cpw.mods.fml.common.Mod.Instance
 import codechicken.microblock.MicroMaterialRegistry
 import codechicken.microblock.DefaultContent
 import cpw.mods.fml.common.event.FMLPostInitializationEvent
+import codechicken.lib.packet.PacketCustom.CustomTinyPacketHandler
 
 @Mod(modid = "ForgeMicroblock", acceptedMinecraftVersions = "[1.6.2]", 
             dependencies="required-after:ForgeMultipart", modLanguage="scala")
+@NetworkMod(clientSideRequired = true, serverSideRequired = true, tinyPacketHandler=classOf[CustomTinyPacketHandler])
 object MicroblockMod
 {
     @PreInit

--- a/codechicken/microblock/handler/PacketHandlers.scala
+++ b/codechicken/microblock/handler/PacketHandlers.scala
@@ -1,0 +1,39 @@
+package codechicken.microblock.handler
+
+import codechicken.lib.packet.PacketCustom.IClientPacketHandler
+import codechicken.lib.packet.PacketCustom.IServerPacketHandler
+import codechicken.lib.packet.PacketCustom
+import net.minecraft.client.multiplayer.NetClientHandler
+import net.minecraft.client.Minecraft
+import codechicken.microblock.MicroMaterialRegistry
+import net.minecraft.network.packet.Packet255KickDisconnect
+import net.minecraft.network.NetServerHandler
+import net.minecraft.entity.player.EntityPlayerMP
+
+class MicroblockPH
+{
+    val registryChannel = "ForgeMicroblock"//Must use the 250 system for ID registry as the NetworkMod idMap hasn't been properly initialized from the server yet.
+}
+
+object MicroblockCPH extends MicroblockPH with IClientPacketHandler
+{
+    def handlePacket(packet:PacketCustom, netHandler:NetClientHandler, mc:Minecraft)
+    {
+        packet.getType match
+        {
+            case 1 => handleMaterialRegistration(packet, netHandler)
+        }
+    }
+    
+    def handleMaterialRegistration(packet:PacketCustom, netHandler:NetClientHandler)
+    {
+        val missing = MicroMaterialRegistry.readIDMap(packet)
+        if(!missing.isEmpty)
+            netHandler.handleKickDisconnect(new Packet255KickDisconnect("The following microblocks are not installed on this client: "+missing.mkString(", ")))
+    }
+}
+
+object MicroblockSPH extends MicroblockPH with IServerPacketHandler
+{
+    def handlePacket(packet:PacketCustom, netHandler:NetServerHandler, sender:EntityPlayerMP){}
+}

--- a/codechicken/microblock/handler/Proxies.scala
+++ b/codechicken/microblock/handler/Proxies.scala
@@ -28,6 +28,8 @@ import net.minecraftforge.oredict.ShapedOreRecipe
 import net.minecraft.block.Block
 import codechicken.lib.lang.LangUtil
 import net.minecraft.util.ResourceLocation
+import codechicken.lib.packet.PacketCustom
+import cpw.mods.fml.common.network.NetworkRegistry
 
 class MicroblockProxy_serverImpl
 {
@@ -54,6 +56,7 @@ class MicroblockProxy_serverImpl
         
         OreDictionary.registerOre("stoneRod", stoneRod)
         MinecraftForge.EVENT_BUS.register(MicroblockEventHandler)
+        NetworkRegistry.instance.registerConnectionHandler(MicroblockEventHandler)
     }
     
     def createSaw(config:ConfigFile, name:String, strength:Int) = 
@@ -98,6 +101,7 @@ class MicroblockProxy_clientImpl extends MicroblockProxy_serverImpl
     {
         super.postInit()
         MinecraftForgeClient.registerItemRenderer(itemMicro.itemID, ItemMicroPartRenderer)
+        PacketCustom.assignHandler(MicroblockCPH.registryChannel, 1, 127, MicroblockCPH)
     }
     
     @SideOnly(Side.CLIENT)


### PR DESCRIPTION
The code is mostly copied from `codechicken.multipart`.

Note: If the client actually has any missing microblocks, it crashes with NPE, but I think [this bug should be fixed in CCL](https://github.com/Chicken-Bones/CodeChickenLib/issues/1).
