### PR TITLE
Add placement sound for microblocks

### DIFF
--- a/codechicken/microblock/BlockMicroMaterial.scala
+++ b/codechicken/microblock/BlockMicroMaterial.scala
@@ -106,6 +106,8 @@ class BlockMicroMaterial(val block:Block, val meta:Int = 0) extends IMicroMateri
     def toolClasses = Seq("axe", "pickaxe", "shovel")
     
     def getCutterStrength = toolClasses.foldLeft(0)((level, tool) => Math.max(level, MinecraftForge.getBlockHarvestLevel(block, meta, tool)))
+    
+    def getSound = block.stepSound
 }
 
 object BlockMicroMaterial

--- a/codechicken/microblock/ItemMicroPart.scala
+++ b/codechicken/microblock/ItemMicroPart.scala
@@ -73,6 +73,10 @@ class ItemMicroPart(id:Int) extends Item(id)
                 placement.place(world, player, item)
                 if(!player.capabilities.isCreativeMode)
                     placement.consume(world, player, item)
+                
+                val sound = MicroMaterialRegistry.getMaterial(material).getSound
+                if(sound != null)
+                    world.playSoundEffect(placement.pos.x + 0.5D, placement.pos.y + 0.5D, placement.pos.z + 0.5D, sound.getPlaceSound, (sound.getVolume + 1.0F) / 2.0F, sound.getPitch * 0.8F)
             }
             
             return true

--- a/codechicken/microblock/MicroMaterialRegistry.scala
+++ b/codechicken/microblock/MicroMaterialRegistry.scala
@@ -17,6 +17,7 @@ import net.minecraft.entity.player.EntityPlayer
 import codechicken.lib.render.Vertex5
 import net.minecraft.item.ItemStack
 import scala.collection.mutable.ListBuffer
+import net.minecraft.block.StepSound
 
 object MicroMaterialRegistry
 {
@@ -45,6 +46,8 @@ object MicroMaterialRegistry
         def getItem():ItemStack
         
         def getCutterStrength():Int
+        
+        def getSound():StepSound
         
         def isSolid() = !isTransparent
         //todo, get material properties


### PR DESCRIPTION
I just don't feel comfortable when I don't hear anything.

This code does not take into account the exact position of the part, it plays sound the same way it is played for normal blocks in `ItemBlock`.
