### PR TITLE
Reorder some operations when one of many parts is removed from a tile

### DIFF
--- a/codechicken/multipart/TileMultipart.scala
+++ b/codechicken/multipart/TileMultipart.scala
@@ -361,10 +361,11 @@ class TileMultipart extends TileEntity
         
         if(!isInvalid)
         {
+            val tile = MultipartGenerator.partRemoved(this, part)
             notifyPartChange(part)
             markDirty()
             markRender()
-            return MultipartGenerator.partRemoved(this, part)
+            return tile
         }
         
         return null


### PR DESCRIPTION
Previously, any redundant interfaces on the tile would still be present (but nulled) at the point that neighbour blocks are notified of the change, causing them to NPE if they try and call the interfaces' methods. Now, the interfaces are removed before adjacent blocks are notified of the change. In testing, this fixes an issue I've been having and doesn't appear to break anything else.
