### PR TITLE
register items with FML so they survive through a 1.7 upgrade

### DIFF
--- a/codechicken/microblock/handler/proxies.scala
+++ b/codechicken/microblock/handler/proxies.scala
@@ -29,6 +29,7 @@ import net.minecraft.block.Block
 import codechicken.lib.lang.LangUtil
 import net.minecraft.util.ResourceLocation
 import codechicken.lib.packet.PacketCustom
+import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.common.network.NetworkRegistry
 import net.minecraft.client.renderer.RenderBlocks
 import java.io.File
@@ -49,10 +50,14 @@ class MicroblockProxy_serverImpl
     {
         itemMicro = new ItemMicroPart(config.getTag("itemMicro.id").getIntValue(nextItemID))
         itemMicro.setUnlocalizedName("microblock")
+        GameRegistry.registerItem(itemMicro, "microblock")
         
         sawStone = createSaw(config, "sawStone", 1)
+        GameRegistry.registerItem(sawStone, "sawStone")
         sawIron = createSaw(config, "sawIron", 2)
+        GameRegistry.registerItem(sawIron, "sawIron")
         sawDiamond = createSaw(config, "sawDiamond", 3)
+        GameRegistry.registerItem(sawDiamond, "sawDiamond")
         stoneRod = new Item(config.getTag("stoneRod.id").getIntValue(nextItemID))
             .setUnlocalizedName("microblock:stoneRod").setTextureName("microblock:stoneRod")
         


### PR DESCRIPTION
This should remove the following "errors" from the FML logfile, as well as allow the items to potentially transition to 1.7

2013-12-04 00:33:54 [SEVERE] [ForgeModLoader] Found anonymous item of class codechicken.microblock.ItemMicroPart with ID 25131 owned by mod ForgeMicroblock, this item will NOT survive a 1.7 upgrade!
2013-12-04 00:33:54 [SEVERE] [ForgeModLoader] Found anonymous item of class codechicken.microblock.ItemSaw with ID 25132 owned by mod ForgeMicroblock, this item will NOT survive a 1.7 upgrade!
2013-12-04 00:33:54 [SEVERE] [ForgeModLoader] Found anonymous item of class codechicken.microblock.ItemSaw with ID 25133 owned by mod ForgeMicroblock, this item will NOT survive a 1.7 upgrade!
2013-12-04 00:33:54 [SEVERE] [ForgeModLoader] Found anonymous item of class codechicken.microblock.ItemSaw with ID 25134 owned by mod ForgeMicroblock, this item will NOT survive a 1.7 upgrade!
