### PR TITLE
Fix empty.max exception

### DIFF
--- a/codechicken/multipart/TileMultipart.scala
+++ b/codechicken/multipart/TileMultipart.scala
@@ -166,11 +166,11 @@ class TileMultipart extends TileEntity
      * Blank implementation, overriden by TTileChangeTile
      */
     def onNeighborTileChange(tileX:Int, tileY:Int, tileZ:Int) {}
-    
-    def getLightValue = partList.view.map(_.getLightValue).max
 
-    def getExplosionResistance(entity:Entity) = partList.view.map(_.explosionResistance(entity)).max
-    
+    def getLightValue = if (partList.isEmpty) 0 else partList.view.map(_.getLightValue).max
+
+    def getExplosionResistance(entity:Entity) = if (partList.isEmpty) 0.0F else partList.view.map(_.explosionResistance(entity)).max
+
     /**
      * Callback for parts to mark the chunk as needs saving
      */


### PR DESCRIPTION
During neighbor updating, if 2 alert each other during a remove, the
empty TileMultipart is asked for a light val which leads to a crash at
partList.view.map(…).max

This will fix this, but the real question is how to remove an _empty_ tile before it is even checked.
